### PR TITLE
Linux and Mac support

### DIFF
--- a/UnityModManager/Mods.cs
+++ b/UnityModManager/Mods.cs
@@ -399,7 +399,7 @@ namespace UnityModManagerNet.Installer
             {
                 foreach (ZipEntry e in zip)
                 {
-                    if (e.FileName.EndsWith(selectedGame.ModInfo))
+                    if (e.FileName.EndsWith(selectedGame.ModInfo, StringComparison.InvariantCultureIgnoreCase))
                     {
                         using (var s = new StreamReader(e.OpenReader()))
                         {

--- a/UnityModManager/Mods.cs
+++ b/UnityModManager/Mods.cs
@@ -45,6 +45,11 @@ namespace UnityModManagerNet.Installer
             if (files.Length == 0)
                 return;
 
+            //Drag and drop files on OS X are in the format /.file/id=6571367.2773272
+            if (Environment.OSVersion.Platform == PlatformID.Unix && files[0].StartsWith("/.file"))
+            {
+                files = files.Select(f => Utils.ResolveOSXFileUrl(f)).ToArray();
+            }
             SaveAndInstallZipFiles(files);
             ReloadMods();
             RefreshModList();
@@ -207,12 +212,25 @@ namespace UnityModManagerNet.Installer
                         File.Delete(filepath);
                     }
                 }
-                zip.ExtractAll(modsPath, ExtractExistingFileAction.OverwriteSilently);
+                foreach(var entry in zip.EntriesSorted)
+                {
+                    if (entry.IsDirectory)
+                    {
+                        Directory.CreateDirectory(Path.Combine(modsPath, entry.FileName));
+                    } else
+                    {
+                        using (FileStream fs = new FileStream(Path.Combine(modsPath, entry.FileName), FileMode.Create, FileAccess.Write))
+                        {
+                            entry.Extract(fs);
+                        }                       
+                    }
+                }
                 Log.Print($"Unpacking '{Path.GetFileName(zip.Name)}' - SUCCESS.");
             }
             catch (Exception ex)
             {
                 Log.Print(ex.Message);
+                Log.Print(ex.StackTrace);
                 Log.Print($"Error when unpacking '{Path.GetFileName(zip.Name)}'.");
             }
 
@@ -236,6 +254,7 @@ namespace UnityModManagerNet.Installer
                 foreach (var dir in Directory.GetDirectories(modsPath))
                 {
                     string jsonPath = Path.Combine(dir, selectedGame.ModInfo);
+                    if (!File.Exists(jsonPath)) jsonPath = Path.Combine(dir, selectedGame.ModInfo.ToLower());
                     if (File.Exists(jsonPath))
                     {
                         try

--- a/UnityModManager/Unity/ModManager.cs
+++ b/UnityModManager/Unity/ModManager.cs
@@ -14,12 +14,12 @@ namespace UnityModManagerNet
     {
         public const string version = "0.12.3";
         public const string modsDirname = "Mods";
-        public const string infoFilename = "info.json";
+        public const string infoFilename = "Info.json";
         public const string patchTarget = "";
 
         private static Version mVersion = new Version();
 
-        public class Repository 
+        public class Repository
         {
             [Serializable]
             public class Release : IEquatable<Release>
@@ -102,7 +102,7 @@ namespace UnityModManagerNet
                         modEntry.Logger.Error(e.ToString());
                     }
                 }
-                
+
                 return t;
             }
         }
@@ -542,6 +542,7 @@ namespace UnityModManagerNet
                 foreach (string dir in Directory.GetDirectories(modsPath))
                 {
                     string jsonPath = Path.Combine(dir, infoFilename);
+                    if (!File.Exists(Path.Combine(dir, infoFilename))) jsonPath = Path.Combine(dir, infoFilename.ToLower());
                     if (File.Exists(jsonPath))
                     {
                         countMods++;
@@ -649,7 +650,7 @@ namespace UnityModManagerNet
         public static void SaveSettingsAndParams()
         {
             mParams.Save();
-            foreach(var mod in modEntries)
+            foreach (var mod in modEntries)
             {
                 if (mod.OnSaveGUI != null)
                     mod.OnSaveGUI(mod);

--- a/UnityModManager/UnityModManager.csproj
+++ b/UnityModManager/UnityModManager.csproj
@@ -51,9 +51,35 @@
     <Reference Include="System.XML" />
     <Reference Include="UnityEngine">
       <HintPath>..\lib\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\lib\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\lib\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>..\lib\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.JSONSerializeModule">
+      <HintPath>..\lib\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\lib\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>..\lib\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestModule">
+      <HintPath>..\lib\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/UnityModManager/Utils.cs
+++ b/UnityModManager/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -73,6 +74,18 @@ namespace UnityModManagerNet.Installer
             }
 
             return true;
+        }
+        public static string ResolveOSXFileUrl(string url)
+        {
+            Process p = new Process();
+            p.StartInfo.UseShellExecute = false;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.FileName = "osascript";
+            p.StartInfo.Arguments = $"-e \"get posix path of posix file \\\"{url}\\\"\"";
+            p.Start();
+            string output = p.StandardOutput.ReadToEnd();
+            p.WaitForExit();
+            return output.TrimEnd();
         }
     }
 }

--- a/Updater/Form.cs
+++ b/Updater/Form.cs
@@ -122,7 +122,20 @@ namespace UnityModManagerNet.Downloader
                     }
                     using (var zip = ZipFile.Read(updateFile))
                     {
-                        zip.ExtractAll(Environment.CurrentDirectory, ExtractExistingFileAction.OverwriteSilently);
+                        foreach (var entry in zip.EntriesSorted)
+                        {
+                            if (entry.IsDirectory)
+                            {
+                                Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, entry.FileName));
+                            }
+                            else
+                            {
+                                using (FileStream fs = new FileStream(Path.Combine(Environment.CurrentDirectory, entry.FileName), FileMode.Create, FileAccess.Write))
+                                {
+                                    entry.Extract(fs);
+                                }
+                            }
+                        }
                     }
                     status.Text = "Done.";
                     success = true;


### PR DESCRIPTION
To add linux and mac support under mono, there are a few changes that need to be made.

* Add search paths for linux/mac
* `Ionic.Zip.ZipEntry.Extract` throws an exception "Path is empty" trying to call System.IO.Directory.CreateDirectory on linux and mac
* Search for both `info.json` and `Info.json` as linux is case sensitive
* On mac file paths from drag and drop are in the format `/.file/id=6571367.2773272` and need to be resolved
* Unrelated to Unix support, I also added unlisted Unity dependencies to references
* When updating, the downloader gets the mod manager using `Process.GetProcessesByName(unityModManagerName)`, this doesn't retrieve the mod manager on linux or mac. I'm not sure about the best way to fix it.

I don't have a machine testing games on linux or mac, so it would be a good idea for some testing before merging.
