### PR TITLE
Fix managed folder path handling for mac

### DIFF
--- a/UnityModManager/Form.cs
+++ b/UnityModManager/Form.cs
@@ -236,8 +236,12 @@ namespace UnityModManagerNet.Installer
         {
             if (Environment.OSVersion.Platform == PlatformID.Unix)
             {
-                var gameName = Path.GetFileName(str);
-                var path = Path.Combine(str, $"{gameName}.app/Contents/Resources/Data/Managed");
+                var appName = $"{Path.GetFileName(str)}.app";
+                if (!Directory.Exists(Path.Combine(str, appName)))
+                {
+                    appName = Directory.GetDirectories(str).FirstOrDefault(dir => dir.EndsWith(".app"));
+                }
+                var path = Path.Combine(str, $"{appName}/Contents/Resources/Data/Managed");
                 if (Directory.Exists(path))
                 {
                     return path;


### PR DESCRIPTION
Fix managed folder searching for mac.
The app package for a game may not match the name supplied by the xml config.
For Pathfinder Kingmaker, the app package is located at
* `~/Library/Application Support/Steam/SteamApps/common/Pathfinder Kingmaker/Kingmaker.app` for steam
* `~/Applications/Pathfinder Kingmaker.app` for GoG

It will search for either the game named in the xml config and it it can't find it, the first app in the current game path.