### PR TITLE
Added debug symbols to assembly load to enable stacktrace line numbers.

### DIFF
--- a/UnityModManager/ModManager.cs
+++ b/UnityModManager/ModManager.cs
@@ -490,12 +490,14 @@ namespace UnityModManagerNet
                     return false;
 
                 string assemblyPath = System.IO.Path.Combine(Path, Info.AssemblyName);
-                
+                string pdbPath = assemblyPath.Replace(".dll", ".pdb");
+
                 if (File.Exists(assemblyPath))
                 {
                     try
                     {
                         var assemblyCachePath = assemblyPath;
+                        var pdbCachePath = pdbPath;
                         var cacheExists = false;
 
                         if (mFirstLoading)
@@ -503,6 +505,7 @@ namespace UnityModManagerNet
                             var fi = new FileInfo(assemblyPath);
                             var hash = (ushort)((long)fi.LastWriteTimeUtc.GetHashCode() + version.GetHashCode() + ManagerVersion.GetHashCode()).GetHashCode();
                             assemblyCachePath = assemblyPath + $".{hash}.cache";
+                            pdbCachePath = assemblyCachePath + ".pdb";
                             cacheExists = File.Exists(assemblyCachePath);
 
                             if (!cacheExists)
@@ -528,6 +531,10 @@ namespace UnityModManagerNet
                                 {
                                     File.Copy(assemblyPath, assemblyCachePath, true);
                                 }
+                                if (File.Exists(pdbPath))
+                                {
+                                    File.Copy(pdbPath, pdbCachePath, true);
+                                }
                                 mAssembly = Assembly.LoadFile(assemblyCachePath);
                                 //mAssembly = Assembly.LoadFile(assemblyPath);
 
@@ -542,7 +549,13 @@ namespace UnityModManagerNet
                             }
                             else
                             {
-                                mAssembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+                                if (File.Exists(pdbPath))
+                                {
+                                    mAssembly = Assembly.Load(File.ReadAllBytes(assemblyPath), File.ReadAllBytes(pdbPath));
+                                } else
+                                {
+                                    mAssembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+                                }
                             }
                         }
                         else

--- a/UnityModManager/UnityModManager.csproj
+++ b/UnityModManager/UnityModManager.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony-1.2">
-      <HintPath>F:\Steam Games\SteamApps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\UnityModManager\0Harmony-1.2.dll</HintPath>
+      <HintPath>..\lib\0Harmony-1.2.dll</HintPath>
     </Reference>
     <Reference Include="0Harmony12">
       <HintPath>..\lib\0Harmony12.dll</HintPath>


### PR DESCRIPTION
#19
Mods can output line numbers in their stacktrace if the game's mono runtime is replaced with [dnspy](https://github.com/0xd4d/dnSpy/releases)'s Unity debug mono runtime and the mod is build with portable debugging symbols. 