### PR TITLE
Fix issues with float settings fields caused by culture settings

### DIFF
--- a/UnityModManager/UIDraw.cs
+++ b/UnityModManager/UIDraw.cs
@@ -401,7 +401,7 @@ namespace UnityModManagerNet
                     }
                     else
                     {
-                        if (float.TryParse(str, System.Globalization.NumberStyles.Any, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                        if (float.TryParse(str, System.Globalization.NumberStyles.Any, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                         {
                             result[i] = num;
                         }
@@ -437,7 +437,7 @@ namespace UnityModManagerNet
                 }
                 else
                 {
-                    if (float.TryParse(str, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                    if (float.TryParse(str, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                     {
                         value = num;
                     }
@@ -481,7 +481,7 @@ namespace UnityModManagerNet
                 }
                 else
                 {
-                    if (int.TryParse(str, System.Globalization.NumberStyles.Integer, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                    if (int.TryParse(str, System.Globalization.NumberStyles.Integer, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                     {
                         value = num;
                     }
@@ -908,7 +908,7 @@ namespace UnityModManagerNet
                                     var val = values[i].ToString();
                                     if (a.Precision >= 0 && isFloat)
                                     {
-                                        if (Double.TryParse(val, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                                        if (Double.TryParse(val, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                                         {
                                             val = num.ToString($"f{a.Precision}");
                                         }
@@ -932,7 +932,7 @@ namespace UnityModManagerNet
                                         }
                                         else
                                         {
-                                            if (Double.TryParse(result, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                                            if (Double.TryParse(result, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                                             {
                                                 num = Math.Max(num, a.Min);
                                                 num = Math.Min(num, a.Max);
@@ -990,7 +990,7 @@ namespace UnityModManagerNet
                         if (!a.Vertical)
                             GUILayout.Space(Scale(5));
                         var val = f.GetValue(container).ToString();
-                        if (!Double.TryParse(val, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.InvariantInfo, out var num))
+                        if (!Double.TryParse(val, System.Globalization.NumberStyles.Float, System.Globalization.NumberFormatInfo.CurrentInfo, out var num))
                         {
                             num = 0;
                         }


### PR DESCRIPTION
When using a culture setting with a different decimal separator than a dot, e.g. the comma that is commonly used in European languages, float values in a settings menu can currently not be edited except by copy-pasting complete values. Since the culture setting is automatically set by Windows this makes them essentially unusable for users of such languages.

The problem is that `float.ToString` by default respects culture settings and therefore fills the field with `0,00` but when changing the field the input is parsed with the `InvariantCulture` setting which always uses a dot as a decimal separator. The value is therefore always invalid and set back to zero (or it is already zero if the change is to remove the comma).

This PR fixes this behavior by changing the parsing code to also use the current culture settings.