### PR TITLE
Actually fix Horizontal attribute on structs/classes

### DIFF
--- a/UnityModManager/UIDraw.cs
+++ b/UnityModManager/UIDraw.cs
@@ -583,7 +583,7 @@ namespace UnityModManagerNet
                         }
                             
                         var box = a.Box || a.Collapsible && collapsibleStates.Exists(x => x == f.MetadataToken);
-                        var horizontal = f.GetCustomAttributes(typeof(HorizontalAttribute), false).Length > 0 || f.GetType().GetCustomAttributes(typeof(HorizontalAttribute), false).Length > 0;
+                        var horizontal = f.GetCustomAttributes(typeof(HorizontalAttribute), false).Length > 0 || f.FieldType.GetCustomAttributes(typeof(HorizontalAttribute), false).Length > 0;
                         if (horizontal)
                         {
                             GUILayout.BeginHorizontal(box ? "box" : "");


### PR DESCRIPTION
I made a slight mistake in my last PR so that while the `Horizontal` attribute indeed now works on fields, it doesn't yet work on classes or structs. This should fix that.