### PR TITLE
Fix Draw annotation for non-default enums

### DIFF
--- a/UnityModManager/UIDraw.cs
+++ b/UnityModManager/UIDraw.cs
@@ -1271,11 +1271,13 @@ namespace UnityModManagerNet
 
                         if (!a.Vertical)
                             GUILayout.Space(Scale(5));
-                        var values = Enum.GetNames(f.FieldType);
+                        var names = Enum.GetNames(f.FieldType);
+                        var values = Enum.GetValues(f.FieldType);
                         var val = (int)f.GetValue(container);
-                        if (PopupToggleGroup(ref val, values, fieldName, unique, null, options.ToArray()))
+                        var index = Array.IndexOf(values, val);
+                        if (PopupToggleGroup(ref index, names, fieldName, unique, null, options.ToArray()))
                         {
-                            var v = Enum.Parse(f.FieldType, values[val]);
+                            var v = Enum.Parse(f.FieldType, names[index]);
                             f.SetValue(container, v);
                             changed = true;
                         }


### PR DESCRIPTION
`DrawType.PopupList` was using the enum's value as an index. This works fine for sequential enums that start at zero, which is the default enum definition. It doesn't work for non-sequential enums or enums that start at a number other than zero. The incompatibility is fixed by finding the index of the currently selected value and passing that to `PopupToggleGroup` instead of the value itself.

Fixes #125.