### PR TITLE
Fix: Ensure derived class fields are saved when not overriding the ModSettings.Save() method

### DIFF
--- a/UnityModManager/ModSettings.cs
+++ b/UnityModManager/ModSettings.cs
@@ -36,7 +36,7 @@ namespace UnityModManagerNet
                 {
                     using (var writer = new StreamWriter(filepath))
                     {
-                        var serializer = new XmlSerializer(typeof(T), attributes);
+                        var serializer = new XmlSerializer(data.GetType(), attributes);
                         serializer.Serialize(writer, data);
                     }
                 }


### PR DESCRIPTION
### The problem:
When inheriting from `ModSettings` without overriding its `Save` method, its base function is called on saving.
```cs
public virtual void Save(ModEntry modEntry)
{
    Save(this, modEntry);
}
```
This will seem fine to most developers, and one might expect it to work flawlessly. However the real result is that the fields of the derived class will never be saved. Interestingly, when the method is copied to the derived class with only the `virtual` keyword changed for an `override` keyword, it works as expected.

### Why does this happen?
The cause for this unintuitive behavior is the static `Save(this, modEntry)` function, which is actually a generic and effectively folds down to a compile-time determined `typeof(this)` call. This always resolves to the class where the function call was defined. In our case, the base `ModSettings` class. 

### The fix:
Instead of using the compile-time determined `typeof(...)` function, this PR switches to use the dynamic `(...).GetType()` function. With that, the type will be determined at runtime and the save function works as one might expect.

### Formalities and honorary mentions:
I compiled and tested the change in a small environment. It appears to be working as expected and seems to not break backwards compatibility with existing implementations. Also, thanks to @WhistleWiz for their help in figuring out this issue.